### PR TITLE
feat: implement Pomodoro timer functionality and UI

### DIFF
--- a/app/api/pomodoro/route.ts
+++ b/app/api/pomodoro/route.ts
@@ -1,0 +1,211 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+
+export interface PomodoroSession {
+  id: string;
+  user_id: string;
+  user_book_id: string | null;
+  started_at: string;
+  ended_at: string | null;
+  duration_minutes: number;
+  completed: boolean;
+  session_type: "work" | "break";
+  created_at: string;
+}
+
+// POST: Create a new pomodoro session
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { user_book_id, duration_minutes, session_type } = body;
+
+    // Validate required fields
+    if (!duration_minutes || typeof duration_minutes !== "number") {
+      return NextResponse.json(
+        { error: "duration_minutes is required and must be a number" },
+        { status: 400 }
+      );
+    }
+
+    if (!session_type || !["work", "break"].includes(session_type)) {
+      return NextResponse.json(
+        { error: "session_type must be 'work' or 'break'" },
+        { status: 400 }
+      );
+    }
+
+    // If user_book_id is provided, verify it belongs to the user
+    if (user_book_id) {
+      const { data: userBook, error: bookError } = await supabase
+        .from("user_books")
+        .select("id")
+        .eq("id", user_book_id)
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (bookError || !userBook) {
+        return NextResponse.json(
+          { error: "Invalid user_book_id" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const { data, error } = await supabase
+      .from("pomodoro_sessions")
+      .insert({
+        user_id: user.id,
+        user_book_id: user_book_id || null,
+        started_at: new Date().toISOString(),
+        duration_minutes,
+        session_type,
+        completed: false,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error("Failed to create pomodoro session:", error);
+      return NextResponse.json(
+        { error: "Failed to create session" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ session: data }, { status: 201 });
+  } catch (error) {
+    console.error("Pomodoro create error:", error);
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+}
+
+// PATCH: Update a pomodoro session (mark as completed)
+export async function PATCH(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { session_id, completed } = body;
+
+    if (!session_id) {
+      return NextResponse.json(
+        { error: "session_id is required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify session belongs to user
+    const { data: existingSession, error: fetchError } = await supabase
+      .from("pomodoro_sessions")
+      .select("id, user_id")
+      .eq("id", session_id)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (fetchError || !existingSession) {
+      return NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    const updateData: { ended_at: string; completed?: boolean } = {
+      ended_at: new Date().toISOString(),
+    };
+
+    if (typeof completed === "boolean") {
+      updateData.completed = completed;
+    }
+
+    const { data, error } = await supabase
+      .from("pomodoro_sessions")
+      .update(updateData)
+      .eq("id", session_id)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("Failed to update pomodoro session:", error);
+      return NextResponse.json(
+        { error: "Failed to update session" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ session: data });
+  } catch (error) {
+    console.error("Pomodoro update error:", error);
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+}
+
+// GET: Fetch user's pomodoro sessions
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const limit = parseInt(searchParams.get("limit") || "50", 10);
+
+  try {
+    const { data, error } = await supabase
+      .from("pomodoro_sessions")
+      .select(`
+        *,
+        user_books (
+          id,
+          title,
+          cover,
+          authors
+        )
+      `)
+      .eq("user_id", user.id)
+      .order("started_at", { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      console.error("Failed to fetch pomodoro sessions:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch sessions" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ sessions: data });
+  } catch (error) {
+    console.error("Pomodoro fetch error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch sessions" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/pomodoro/page.tsx
+++ b/app/dashboard/pomodoro/page.tsx
@@ -1,0 +1,37 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { PomodoroTimer } from "@/components/pomodoro/pomodoro-timer";
+
+export default async function PomodoroPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  // Fetch user's currently reading books for the book selector
+  const { data: userBooks } = await supabase
+    .from("user_books")
+    .select("id, title, cover, authors")
+    .eq("user_id", user.id)
+    .eq("status", "IS_READING")
+    .order("updated_at", { ascending: false });
+
+  const books = userBooks || [];
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Pomodoro Timer</h1>
+        <p className="text-muted-foreground mt-2">
+          Focus on your reading with timed work sessions.
+        </p>
+      </div>
+
+      <PomodoroTimer books={books} />
+    </div>
+  );
+}

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -30,6 +30,7 @@ import {
 import { BookSearch } from "@/components/shelf/book-search";
 import { usePresence } from "@/contexts/presence-context";
 import { useAuth } from "@/contexts/auth-context";
+import { Button } from "../ui/button";
 
 interface DashboardHeaderProps {
   userEmail: string | undefined;
@@ -107,19 +108,17 @@ export function DashboardHeader({
           {/* Book Search and Pomodoro */}
           <div className="flex items-center gap-2">
             <BookSearch />
+
             <Link
               href="/dashboard/pomodoro"
               prefetch={false}
-              className={cn(
-                "flex items-center justify-center h-9 w-9 rounded-md transition-colors",
-                pathname.startsWith("/dashboard/pomodoro")
-                  ? "bg-primary text-primary-foreground"
-                  : "hover:bg-accent hover:text-accent-foreground"
-              )}
               title="Pomodoro Timer"
             >
-              <Timer className="h-5 w-5" />
+              <Button variant="outline" size="icon">
+                <Timer className="h-5 w-5" />
+              </Button>
             </Link>
+
 
             <div className="flex items-center gap-2 flex-shrink-0">
               <DropdownMenu>

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -38,7 +38,6 @@ interface DashboardHeaderProps {
 
 const navItems = [
   { href: "/dashboard/shelf", label: "Shelf", icon: Library },
-  { href: "/dashboard/pomodoro", label: "Pomodoro", icon: Timer },
   { href: "/dashboard/statistics", label: "Statistics", icon: BarChart3 },
   { href: "/dashboard/communities", label: "Communities", icon: Users },
 ];
@@ -105,9 +104,22 @@ export function DashboardHeader({
             </span>
           </Link>
 
-          {/* Book Search */}
+          {/* Book Search and Pomodoro */}
           <div className="flex items-center gap-2">
             <BookSearch />
+            <Link
+              href="/dashboard/pomodoro"
+              prefetch={false}
+              className={cn(
+                "flex items-center justify-center h-9 w-9 rounded-md transition-colors",
+                pathname.startsWith("/dashboard/pomodoro")
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-accent hover:text-accent-foreground"
+              )}
+              title="Pomodoro Timer"
+            >
+              <Timer className="h-5 w-5" />
+            </Link>
 
             <div className="flex items-center gap-2 flex-shrink-0">
               <DropdownMenu>

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -11,6 +11,7 @@ import {
   Circle,
   CircleOff,
   BarChart3,
+  Timer,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useTheme } from "next-themes";
@@ -37,6 +38,7 @@ interface DashboardHeaderProps {
 
 const navItems = [
   { href: "/dashboard/shelf", label: "Shelf", icon: Library },
+  { href: "/dashboard/pomodoro", label: "Pomodoro", icon: Timer },
   { href: "/dashboard/statistics", label: "Statistics", icon: BarChart3 },
   { href: "/dashboard/communities", label: "Communities", icon: Users },
 ];

--- a/components/pomodoro/pomodoro-timer.tsx
+++ b/components/pomodoro/pomodoro-timer.tsx
@@ -193,7 +193,7 @@ export function PomodoroTimer({ books }: PomodoroTimerProps) {
     if (sessionType === "work") {
       showNotification("Work Session Complete!", "Time for a break.");
       toast.success("Work session complete! Time for a break.");
-      
+
       // Revert status to online after work session
       if (previousStatusRef.current) {
         await setStatus(previousStatusRef.current as "online" | "offline");
@@ -246,6 +246,7 @@ export function PomodoroTimer({ books }: PomodoroTimerProps) {
     // Set status to reading for work sessions
     if (sessionType === "work" && user) {
       const currentStatus = getUserStatus(user.id);
+      console.log("currentStatus", currentStatus);
       previousStatusRef.current = currentStatus;
       await setStatus("reading");
     }
@@ -324,7 +325,7 @@ export function PomodoroTimer({ books }: PomodoroTimerProps) {
   const handleSaveSettings = () => {
     setSettings(tempSettings);
     localStorage.setItem(LOCAL_SETTINGS_KEY, JSON.stringify(tempSettings));
-    
+
     // Update time remaining if idle
     if (timerState === "idle") {
       setTimeRemaining(
@@ -333,7 +334,7 @@ export function PomodoroTimer({ books }: PomodoroTimerProps) {
           : tempSettings.breakDuration * 60
       );
     }
-    
+
     setSettingsOpen(false);
     toast.success("Settings saved");
   };
@@ -406,8 +407,8 @@ export function PomodoroTimer({ books }: PomodoroTimerProps) {
                 {timerState === "running"
                   ? "Running"
                   : timerState === "paused"
-                  ? "Paused"
-                  : "Ready"}
+                    ? "Paused"
+                    : "Ready"}
               </span>
             </div>
           </div>

--- a/components/pomodoro/pomodoro-timer.tsx
+++ b/components/pomodoro/pomodoro-timer.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Play, Pause, Square, RotateCcw, Settings, BookOpen } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { usePresence } from "@/contexts/presence-context";
+import { useAuth } from "@/contexts/auth-context";
+import { cn } from "@/lib/utils";
+
+interface UserBook {
+  id: string;
+  title: string;
+  cover: string | null;
+  authors: { name: string }[] | null;
+}
+
+type TimerState = "idle" | "running" | "paused";
+type SessionType = "work" | "break";
+
+const LOCAL_SETTINGS_KEY = "pomodoro_settings";
+
+interface PomodoroSettings {
+  workDuration: number; // in minutes
+  breakDuration: number; // in minutes
+}
+
+const DEFAULT_SETTINGS: PomodoroSettings = {
+  workDuration: 25,
+  breakDuration: 5,
+};
+
+interface PomodoroTimerProps {
+  books: UserBook[];
+}
+
+export function PomodoroTimer({ books }: PomodoroTimerProps) {
+  const { user } = useAuth();
+  const { setStatus, getUserStatus } = usePresence();
+
+  // Settings state
+  const [settings, setSettings] = useState<PomodoroSettings>(DEFAULT_SETTINGS);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [tempSettings, setTempSettings] = useState<PomodoroSettings>(DEFAULT_SETTINGS);
+
+  // Timer state
+  const [timerState, setTimerState] = useState<TimerState>("idle");
+  const [sessionType, setSessionType] = useState<SessionType>("work");
+  const [timeRemaining, setTimeRemaining] = useState(settings.workDuration * 60); // in seconds
+  const [selectedBookId, setSelectedBookId] = useState<string | null>(null);
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+
+  // Refs for interval and previous status
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const previousStatusRef = useRef<string | null>(null);
+  const notificationPermissionRef = useRef<NotificationPermission>("default");
+
+  // Load settings from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem(LOCAL_SETTINGS_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as PomodoroSettings;
+        setSettings(parsed);
+        setTempSettings(parsed);
+        // Only update time if timer is idle
+        if (timerState === "idle") {
+          setTimeRemaining(parsed.workDuration * 60);
+        }
+      } catch {
+        // Use defaults
+      }
+    }
+    // Check notification permission
+    if ("Notification" in window) {
+      notificationPermissionRef.current = Notification.permission;
+    }
+  }, []);
+
+  // Request notification permission
+  const requestNotificationPermission = useCallback(async () => {
+    if (!("Notification" in window)) return;
+    if (Notification.permission === "default") {
+      const permission = await Notification.requestPermission();
+      notificationPermissionRef.current = permission;
+    }
+  }, []);
+
+  // Show notification
+  const showNotification = useCallback((title: string, body: string) => {
+    if (!("Notification" in window)) return;
+    if (Notification.permission === "granted") {
+      new Notification(title, {
+        body,
+        icon: "/favicon.ico",
+        tag: "pomodoro",
+      });
+    }
+  }, []);
+
+  // Create session in database
+  const createSession = useCallback(async (
+    durationMinutes: number,
+    type: SessionType,
+    bookId: string | null
+  ): Promise<string | null> => {
+    try {
+      const response = await fetch("/api/pomodoro", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          duration_minutes: durationMinutes,
+          session_type: type,
+          user_book_id: bookId,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create session");
+      }
+
+      const data = await response.json();
+      return data.session?.id || null;
+    } catch (error) {
+      console.error("Failed to create pomodoro session:", error);
+      return null;
+    }
+  }, []);
+
+  // Update session in database
+  const updateSession = useCallback(async (sessionId: string, completed: boolean) => {
+    try {
+      await fetch("/api/pomodoro", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: sessionId,
+          completed,
+        }),
+      });
+    } catch (error) {
+      console.error("Failed to update pomodoro session:", error);
+    }
+  }, []);
+
+  // Format time as MM:SS
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  // Calculate progress percentage
+  const getProgress = (): number => {
+    const totalSeconds =
+      sessionType === "work"
+        ? settings.workDuration * 60
+        : settings.breakDuration * 60;
+    return ((totalSeconds - timeRemaining) / totalSeconds) * 100;
+  };
+
+  // Handle timer completion
+  const handleTimerComplete = useCallback(async () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    // Mark session as completed
+    if (currentSessionId) {
+      await updateSession(currentSessionId, true);
+      setCurrentSessionId(null);
+    }
+
+    // Show notification and toast
+    if (sessionType === "work") {
+      showNotification("Work Session Complete!", "Time for a break.");
+      toast.success("Work session complete! Time for a break.");
+      
+      // Revert status to online after work session
+      if (previousStatusRef.current) {
+        await setStatus(previousStatusRef.current as "online" | "offline");
+        previousStatusRef.current = null;
+      } else {
+        await setStatus("online");
+      }
+    } else {
+      showNotification("Break Over!", "Ready to focus?");
+      toast.success("Break over! Ready to focus?");
+    }
+
+    // Switch to next session type
+    const nextType: SessionType = sessionType === "work" ? "break" : "work";
+    setSessionType(nextType);
+    setTimeRemaining(
+      nextType === "work"
+        ? settings.workDuration * 60
+        : settings.breakDuration * 60
+    );
+    setTimerState("idle");
+  }, [sessionType, settings, currentSessionId, updateSession, setStatus, showNotification]);
+
+  // Timer tick effect
+  useEffect(() => {
+    if (timerState === "running" && timeRemaining > 0) {
+      intervalRef.current = setInterval(() => {
+        setTimeRemaining((prev) => {
+          if (prev <= 1) {
+            handleTimerComplete();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [timerState, handleTimerComplete]);
+
+  // Start timer
+  const handleStart = async () => {
+    await requestNotificationPermission();
+
+    // Set status to reading for work sessions
+    if (sessionType === "work" && user) {
+      const currentStatus = getUserStatus(user.id);
+      previousStatusRef.current = currentStatus;
+      await setStatus("reading");
+    }
+
+    // Create session in database
+    const sessionId = await createSession(
+      sessionType === "work" ? settings.workDuration : settings.breakDuration,
+      sessionType,
+      selectedBookId
+    );
+    setCurrentSessionId(sessionId);
+
+    setTimerState("running");
+  };
+
+  // Pause timer
+  const handlePause = () => {
+    setTimerState("paused");
+  };
+
+  // Resume timer
+  const handleResume = () => {
+    setTimerState("running");
+  };
+
+  // Stop timer
+  const handleStop = async () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    // Mark session as incomplete
+    if (currentSessionId) {
+      await updateSession(currentSessionId, false);
+      setCurrentSessionId(null);
+    }
+
+    // Revert status
+    if (sessionType === "work") {
+      if (previousStatusRef.current) {
+        await setStatus(previousStatusRef.current as "online" | "offline");
+        previousStatusRef.current = null;
+      } else {
+        await setStatus("online");
+      }
+    }
+
+    setTimerState("idle");
+    setTimeRemaining(
+      sessionType === "work"
+        ? settings.workDuration * 60
+        : settings.breakDuration * 60
+    );
+  };
+
+  // Reset timer
+  const handleReset = () => {
+    setTimeRemaining(
+      sessionType === "work"
+        ? settings.workDuration * 60
+        : settings.breakDuration * 60
+    );
+  };
+
+  // Switch session type (only when idle)
+  const handleSessionTypeChange = (type: SessionType) => {
+    if (timerState !== "idle") return;
+    setSessionType(type);
+    setTimeRemaining(
+      type === "work" ? settings.workDuration * 60 : settings.breakDuration * 60
+    );
+  };
+
+  // Save settings
+  const handleSaveSettings = () => {
+    setSettings(tempSettings);
+    localStorage.setItem(LOCAL_SETTINGS_KEY, JSON.stringify(tempSettings));
+    
+    // Update time remaining if idle
+    if (timerState === "idle") {
+      setTimeRemaining(
+        sessionType === "work"
+          ? tempSettings.workDuration * 60
+          : tempSettings.breakDuration * 60
+      );
+    }
+    
+    setSettingsOpen(false);
+    toast.success("Settings saved");
+  };
+
+  const selectedBook = books.find((b) => b.id === selectedBookId);
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      {/* Session Type Toggle */}
+      <div className="flex gap-2">
+        <Button
+          variant={sessionType === "work" ? "default" : "outline"}
+          onClick={() => handleSessionTypeChange("work")}
+          disabled={timerState !== "idle"}
+        >
+          Work
+        </Button>
+        <Button
+          variant={sessionType === "break" ? "default" : "outline"}
+          onClick={() => handleSessionTypeChange("break")}
+          disabled={timerState !== "idle"}
+        >
+          Break
+        </Button>
+      </div>
+
+      {/* Timer Display */}
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center pb-2">
+          <CardTitle className="text-lg text-muted-foreground">
+            {sessionType === "work" ? "Focus Time" : "Break Time"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-6">
+          {/* Circular Progress Timer */}
+          <div className="relative">
+            <svg className="w-64 h-64 transform -rotate-90">
+              {/* Background circle */}
+              <circle
+                cx="128"
+                cy="128"
+                r="120"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="8"
+                className="text-muted"
+              />
+              {/* Progress circle */}
+              <circle
+                cx="128"
+                cy="128"
+                r="120"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="8"
+                strokeLinecap="round"
+                strokeDasharray={2 * Math.PI * 120}
+                strokeDashoffset={2 * Math.PI * 120 * (1 - getProgress() / 100)}
+                className={cn(
+                  "transition-all duration-1000",
+                  sessionType === "work" ? "text-purple-500" : "text-green-500"
+                )}
+              />
+            </svg>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <span className="text-5xl font-mono font-bold tabular-nums">
+                {formatTime(timeRemaining)}
+              </span>
+              <span className="text-sm text-muted-foreground mt-2">
+                {timerState === "running"
+                  ? "Running"
+                  : timerState === "paused"
+                  ? "Paused"
+                  : "Ready"}
+              </span>
+            </div>
+          </div>
+
+          {/* Controls */}
+          <div className="flex gap-3">
+            {timerState === "idle" && (
+              <Button size="lg" onClick={handleStart}>
+                <Play className="mr-2 h-5 w-5" />
+                Start
+              </Button>
+            )}
+            {timerState === "running" && (
+              <>
+                <Button size="lg" variant="outline" onClick={handlePause}>
+                  <Pause className="mr-2 h-5 w-5" />
+                  Pause
+                </Button>
+                <Button size="lg" variant="destructive" onClick={handleStop}>
+                  <Square className="mr-2 h-5 w-5" />
+                  Stop
+                </Button>
+              </>
+            )}
+            {timerState === "paused" && (
+              <>
+                <Button size="lg" onClick={handleResume}>
+                  <Play className="mr-2 h-5 w-5" />
+                  Resume
+                </Button>
+                <Button size="lg" variant="outline" onClick={handleReset}>
+                  <RotateCcw className="mr-2 h-5 w-5" />
+                  Reset
+                </Button>
+                <Button size="lg" variant="destructive" onClick={handleStop}>
+                  <Square className="mr-2 h-5 w-5" />
+                  Stop
+                </Button>
+              </>
+            )}
+          </div>
+
+          {/* Book Selection */}
+          {sessionType === "work" && (
+            <div className="w-full space-y-2">
+              <Label className="text-sm text-muted-foreground flex items-center gap-2">
+                <BookOpen className="h-4 w-4" />
+                Reading (optional)
+              </Label>
+              <Select
+                value={selectedBookId || "none"}
+                onValueChange={(value) =>
+                  setSelectedBookId(value === "none" ? null : value)
+                }
+                disabled={timerState !== "idle"}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a book...">
+                    {selectedBook ? (
+                      <span className="truncate">{selectedBook.title}</span>
+                    ) : (
+                      "No book selected"
+                    )}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No book selected</SelectItem>
+                  {books.map((book) => (
+                    <SelectItem key={book.id} value={book.id}>
+                      <span className="truncate">{book.title}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Settings Dialog */}
+      <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+        <DialogTrigger asChild>
+          <Button variant="ghost" size="sm" disabled={timerState !== "idle"}>
+            <Settings className="mr-2 h-4 w-4" />
+            Settings
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Timer Settings</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="work-duration">Work Duration (minutes)</Label>
+              <Input
+                id="work-duration"
+                type="number"
+                min={1}
+                max={120}
+                value={tempSettings.workDuration}
+                onChange={(e) =>
+                  setTempSettings((prev) => ({
+                    ...prev,
+                    workDuration: parseInt(e.target.value) || 25,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="break-duration">Break Duration (minutes)</Label>
+              <Input
+                id="break-duration"
+                type="number"
+                min={1}
+                max={60}
+                value={tempSettings.breakDuration}
+                onChange={(e) =>
+                  setTempSettings((prev) => ({
+                    ...prev,
+                    breakDuration: parseInt(e.target.value) || 5,
+                  }))
+                }
+              />
+            </div>
+            <Button onClick={handleSaveSettings} className="w-full">
+              Save Settings
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -108,7 +108,7 @@ The app tracks user online status using a database polling approach (no WebSocke
 2. **Status Query**: Periodically fetches users with `last_seen` within the last 2 minutes.
 3. **Status Display**: Shows colored dot indicators on user avatars:
    - **Green**: User is online (active within 2 minutes)
-   - **Purple**: User is reading (pomodoro timer active - future feature)
+   - **Purple**: User is reading (pomodoro timer active)
    - **No indicator**: User is offline
 
 #### Key Components

--- a/migrations/014_create_pomodoro_sessions.sql
+++ b/migrations/014_create_pomodoro_sessions.sql
@@ -1,0 +1,45 @@
+-- Create pomodoro_sessions table to track timer usage
+-- Each session can optionally be linked to a book the user is reading
+
+CREATE TABLE pomodoro_sessions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_book_id UUID REFERENCES user_books(id) ON DELETE SET NULL,
+  
+  -- Session details
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ,
+  duration_minutes INTEGER NOT NULL, -- Planned duration
+  completed BOOLEAN DEFAULT false,
+  session_type TEXT NOT NULL CHECK (session_type IN ('work', 'break')),
+  
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for efficient querying
+CREATE INDEX idx_pomodoro_sessions_user_id ON pomodoro_sessions(user_id);
+CREATE INDEX idx_pomodoro_sessions_user_book_id ON pomodoro_sessions(user_book_id);
+CREATE INDEX idx_pomodoro_sessions_started_at ON pomodoro_sessions(started_at);
+
+-- Enable RLS
+ALTER TABLE pomodoro_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own pomodoro sessions
+CREATE POLICY "Users can view their own pomodoro sessions"
+  ON pomodoro_sessions FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can insert their own pomodoro sessions
+CREATE POLICY "Users can insert their own pomodoro sessions"
+  ON pomodoro_sessions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can update their own pomodoro sessions
+CREATE POLICY "Users can update their own pomodoro sessions"
+  ON pomodoro_sessions FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- Policy: Users can delete their own pomodoro sessions
+CREATE POLICY "Users can delete their own pomodoro sessions"
+  ON pomodoro_sessions FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
- Added a new API endpoint for managing Pomodoro sessions, allowing users to create, update, and fetch their timer sessions.
- Introduced a PomodoroTimer component for the dashboard, enabling users to start, pause, and reset their timer sessions with book selection.
- Updated the dashboard header to include a link to the Pomodoro page.
- Enhanced the database schema with a new `pomodoro_sessions` table to track user sessions, including session type and duration.
- Updated documentation to reflect the new Pomodoro feature and its database schema.