### PR TITLE
refactor: replace fetch calls with utility function for Open Library API

### DIFF
--- a/app/api/books/[id]/route.ts
+++ b/app/api/books/[id]/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { fetchFromOpenLibrary } from "@/lib/openlibrary";
 import { NextRequest, NextResponse } from "next/server";
 
 export interface BookEditionDetails {
@@ -34,7 +35,7 @@ async function getBookEditionFromOpenLibrary(
 ): Promise<BookEditionDetails | null> {
   try {
     // Fetch edition details
-    const bookResponse = await fetch(
+    const bookResponse = await fetchFromOpenLibrary(
       `https://openlibrary.org/books/${bookKey}.json`
     );
 
@@ -48,7 +49,7 @@ async function getBookEditionFromOpenLibrary(
     const workKey = book.works?.[0]?.key?.replace("/works/", "") || null;
     let work = null;
     if (workKey) {
-      const workResponse = await fetch(
+      const workResponse = await fetchFromOpenLibrary(
         `https://openlibrary.org/works/${workKey}.json`
       );
       if (workResponse.ok) {
@@ -63,7 +64,7 @@ async function getBookEditionFromOpenLibrary(
       if (!authorKey) return null;
 
       try {
-        const authorResponse = await fetch(
+        const authorResponse = await fetchFromOpenLibrary(
           `https://openlibrary.org${authorKey}.json`
         );
         if (authorResponse.ok) {

--- a/app/api/editions/route.ts
+++ b/app/api/editions/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { fetchFromOpenLibrary } from "@/lib/openlibrary";
 import { NextRequest, NextResponse } from "next/server";
 
 export interface BookEdition {
@@ -38,7 +39,7 @@ async function getEditionsFromOpenLibrary(
     );
 
     // Fetch work details to get title
-    const workResponse = await fetch(
+    const workResponse = await fetchFromOpenLibrary(
       `https://openlibrary.org/works/${workKey}.json`
     );
 
@@ -54,7 +55,7 @@ async function getEditionsFromOpenLibrary(
     const editionsUrl = `https://openlibrary.org/works/${workKey}/editions.json?offset=${offset}&limit=${limit}`;
     console.log(`Fetching editions from: ${editionsUrl}`);
 
-    const editionsResponse = await fetch(editionsUrl);
+    const editionsResponse = await fetchFromOpenLibrary(editionsUrl);
 
     if (!editionsResponse.ok) {
       console.error(`Editions fetch failed: ${editionsResponse.status}`);

--- a/app/api/works/[id]/route.ts
+++ b/app/api/works/[id]/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { fetchFromOpenLibrary } from "@/lib/openlibrary";
 import { NextRequest, NextResponse } from "next/server";
 
 export interface WorkDetails {
@@ -20,7 +21,7 @@ async function getWorkFromOpenLibrary(
 ): Promise<WorkDetails | null> {
   try {
     // Fetch work details
-    const workResponse = await fetch(
+    const workResponse = await fetchFromOpenLibrary(
       `https://openlibrary.org/works/${workKey}.json`
     );
 
@@ -36,7 +37,7 @@ async function getWorkFromOpenLibrary(
       if (!authorKey) return null;
 
       try {
-        const authorResponse = await fetch(
+        const authorResponse = await fetchFromOpenLibrary(
           `https://openlibrary.org${authorKey}.json`
         );
         if (authorResponse.ok) {

--- a/app/api/works/search/route.ts
+++ b/app/api/works/search/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { fetchFromOpenLibrary } from "@/lib/openlibrary";
 import { NextRequest, NextResponse } from "next/server";
 
 interface BookSearchResult {
@@ -27,7 +28,7 @@ async function searchWorksInOpenLibrary(
     url.searchParams.set("mode", "everything");
     url.searchParams.set("_spellcheck_count", "0");
 
-    const response = await fetch(url.toString());
+    const response = await fetchFromOpenLibrary(url);
 
     if (!response.ok) {
       console.error("Open Library API error:", response.status);

--- a/lib/openlibrary.ts
+++ b/lib/openlibrary.ts
@@ -1,0 +1,14 @@
+/**
+ * Utility function for making requests to the Open Library API
+ * with proper User-Agent headers as required by their API guidelines.
+ */
+export async function fetchFromOpenLibrary(url: string | URL): Promise<Response> {
+  const headers = new Headers({
+    "User-Agent": "koinon.app/1.0 (kuzeyko@outlook.com)"
+  });
+
+  return fetch(url.toString(), {
+    method: 'GET',
+    headers: headers
+  });
+}


### PR DESCRIPTION
- Introduced a new utility function `fetchFromOpenLibrary` to standardize API requests to the Open Library, ensuring proper User-Agent headers are included.
- Updated existing API routes for books, editions, works, and search to utilize the new utility function, improving code maintainability and readability.