### PR TITLE
feat: add online status preference functionality

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/contexts/auth-context";
+import { usePresence } from "@/contexts/presence-context";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
@@ -20,9 +21,15 @@ import { Check, Copy, Loader2 } from "lucide-react";
 
 export default function SettingsPage() {
   const { user } = useAuth();
+  const {
+    showOnlineStatus,
+    updateOnlinePreference,
+    isLoading: isPresenceLoading,
+  } = usePresence();
   const [isPublic, setIsPublic] = useState(false);
   const [isStatsPublic, setIsStatsPublic] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [isUpdatingOnlineStatus, setIsUpdatingOnlineStatus] = useState(false);
   const [username, setUsername] = useState("");
   const [originalUsername, setOriginalUsername] = useState("");
   const [usernameInput, setUsernameInput] = useState("");
@@ -183,6 +190,25 @@ export default function SettingsPage() {
     }
   };
 
+  // Handle toggle change for online status visibility
+  const handleToggleOnlineStatus = async (checked: boolean) => {
+    setIsUpdatingOnlineStatus(true);
+
+    const success = await updateOnlinePreference(checked);
+
+    setIsUpdatingOnlineStatus(false);
+
+    if (!success) {
+      toast.error("Failed to update online status preference");
+    } else {
+      toast.success(
+        checked
+          ? "You will now appear online when active"
+          : "You will appear offline to others"
+      );
+    }
+  };
+
   // Copy profile URL
   const copyProfileUrl = () => {
     const url = `${window.location.origin}/dashboard/profile/${username}`;
@@ -193,9 +219,8 @@ export default function SettingsPage() {
   };
 
   const profileUrl = username
-    ? `${
-        typeof window !== "undefined" ? window.location.origin : ""
-      }/dashboard/profile/${username}`
+    ? `${typeof window !== "undefined" ? window.location.origin : ""
+    }/dashboard/profile/${username}`
     : "";
 
   return (
@@ -252,8 +277,8 @@ export default function SettingsPage() {
                       usernameError
                         ? "border-destructive pr-10"
                         : isUsernameAvailable
-                        ? "border-green-500 pr-10"
-                        : ""
+                          ? "border-green-500 pr-10"
+                          : ""
                     }
                     disabled={isLoading}
                   />
@@ -326,6 +351,22 @@ export default function SettingsPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="show-online-status" className="text-base">
+                  Show Online Status
+                </Label>
+                <p className="text-sm text-muted-foreground">
+                  Allow others to see when you&apos;re online or reading
+                </p>
+              </div>
+              <Switch
+                id="show-online-status"
+                checked={showOnlineStatus}
+                onCheckedChange={handleToggleOnlineStatus}
+                disabled={isLoading || isPresenceLoading || isUpdatingOnlineStatus}
+              />
+            </div>
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
                 <Label htmlFor="public-profile" className="text-base">

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -52,13 +52,18 @@ export function DashboardHeader({
   const supabase = createClient();
   const { theme, setTheme } = useTheme();
   const { user } = useAuth();
-  const { getUserStatus, setStatus } = usePresence();
+  const { getUserStatus, setStatus, showOnlineStatus } = usePresence();
 
   const currentStatus = user ? getUserStatus(user.id) : "offline";
   const isOnline = currentStatus !== "offline";
 
   const handleStatusChange = async (nextStatus: "online" | "offline") => {
     if (nextStatus === currentStatus) return;
+    // If preference is disabled and trying to go online, block it
+    if (!showOnlineStatus && nextStatus === "online") {
+      toast.error("Enable 'Show Online Status' in settings first");
+      return;
+    }
     const didUpdate = await setStatus(nextStatus);
     if (didUpdate) {
       toast.success(
@@ -195,9 +200,11 @@ export function DashboardHeader({
                           "rounded-sm p-1.5 transition-colors",
                           isOnline
                             ? "bg-background shadow-sm"
-                            : "hover:bg-background/50"
+                            : "hover:bg-background/50",
+                          !showOnlineStatus && "opacity-50 cursor-not-allowed"
                         )}
-                        title="Online"
+                        title={showOnlineStatus ? "Online" : "Enable in settings"}
+                        disabled={!showOnlineStatus}
                       >
                         <Circle
                           className={cn(

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -234,7 +234,8 @@ CREATE TABLE profiles (
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   -- Presence tracking
   last_seen TIMESTAMPTZ, -- Last activity timestamp (updated every ~30 seconds)
-  status TEXT DEFAULT 'offline' -- Current status: 'online', 'reading', 'offline'
+  status TEXT DEFAULT 'offline', -- Current status: 'online', 'reading', 'offline'
+  show_online_status BOOLEAN DEFAULT true, -- User preference: whether to show online status to others
   is_stats_public BOOLEAN DEFAULT false, -- Controls whether user's reading statistics are publicly viewable
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
@@ -242,6 +243,7 @@ CREATE TABLE profiles (
 -- Indexes for presence queries
 CREATE INDEX idx_profiles_last_seen ON profiles(last_seen);
 CREATE INDEX idx_profiles_status ON profiles(status);
+CREATE INDEX idx_profiles_show_online_status ON profiles(show_online_status);
 
 -- Enable RLS
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
@@ -317,6 +319,23 @@ CREATE INDEX IF NOT EXISTS idx_profiles_status ON profiles(status);
 - `online`: User is active on the site
 - `reading`: User has an active pomodoro timer
 - `offline`: User is inactive or manually set themselves invisible
+
+### Migration 015: Online Status Preference
+
+Adds a user preference to control online status visibility:
+
+```sql
+-- File: migrations/015_add_online_status_preference.sql
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS show_online_status BOOLEAN DEFAULT true;
+CREATE INDEX IF NOT EXISTS idx_profiles_show_online_status ON profiles(show_online_status);
+```
+
+**Online Status Preference (`show_online_status`):**
+- Controls whether the user wants to appear online to others
+- When `true` (default): User automatically appears online when active
+- When `false`: User always appears offline, regardless of activity
+- Can be toggled in Settings > Privacy Settings
 
 ## Notes
 

--- a/migrations/015_add_online_status_preference.sql
+++ b/migrations/015_add_online_status_preference.sql
@@ -1,0 +1,11 @@
+-- Migration: Add online status preference to profiles
+-- This allows users to control whether they appear online to others
+
+-- Add the preference column (default true = show online status)
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS show_online_status BOOLEAN DEFAULT true;
+
+-- Add index for efficient querying
+CREATE INDEX IF NOT EXISTS idx_profiles_show_online_status ON profiles(show_online_status);
+
+-- Comment explaining the field
+COMMENT ON COLUMN profiles.show_online_status IS 'User preference: whether to show online status to others. When false, user always appears offline.';


### PR DESCRIPTION
- Introduced a new user preference for showing online status, allowing users to control visibility in settings.
- Updated PresenceProvider to manage the online status preference and ensure proper status updates based on user settings.
- Enhanced SettingsPage to include a toggle for the online status visibility, with corresponding feedback on preference changes.
- Modified DashboardHeader to respect the online status preference when changing user status.
- Updated database schema to include `show_online_status` field in profiles, enabling persistence of user preferences.